### PR TITLE
⚡ Bolt: 2D Encode Software Optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,8 @@
+## 2024-05-25 - Hardware Intrinsic Optimizations in Morton Encoding
+**Observation:** The `Tedd.MortonEncoding` library uses software fallbacks (`AND`, `XOR`, `SHIFT`) to perform 2D and 3D Morton encoding/decoding when `System.Runtime.Intrinsics.X86.Bmi2` is not supported. The `Encode` and `Decode` logic utilizes `Bmi2.ParallelBitDeposit` and `Bmi2.ParallelBitExtract` when `Bmi2` is available.
+The BMI2 intrinsic methods, when measured using BenchmarkDotNet on RyuJIT x86-64-v3 with .NET 10.0, show extreme micro-optimization levels relative to software bitwise implementation (nearly ~0.0 ns and indistinguishable from empty methods due to method inlining and direct CPU instruction mapping).
+**Strategic Action:** Continue evaluating other intrinsic acceleration opportunities.
+
+## 2024-05-25 - Redundant Shift and OR Elimination in Software Fallback
+**Observation:** In the `Encode(UInt32 x, UInt32 y)` software fallback, operations like `x = (x | x << 16) & 0x0000FFFF` shift bits into the upper 16 positions, but then immediately apply a mask (`0x0000FFFF`) that clears them, making the shift and OR entirely redundant. Removing these operations reduces latency from 3.153 ns to 2.633 ns per benchmark.
+**Strategic Action:** Always inspect bitwise operations before applying masks to detect and eliminate dead operations (O(1) Time, O(1) Space).

--- a/src/Tedd.MortonEncoding.Benchmarks/EncodingBenchmark.cs
+++ b/src/Tedd.MortonEncoding.Benchmarks/EncodingBenchmark.cs
@@ -17,9 +17,9 @@ namespace Tedd.Benchmarks
         public void Setup()
         {
             var rand = new Random(42);
-            _x = (uint)rand.Next(0, 65535);
-            _y = (uint)rand.Next(0, 65535);
-            _z = (uint)rand.Next(0, 1023);
+            _x = (uint)rand.Next(0, 65536);
+            _y = (uint)rand.Next(0, 65536);
+            _z = (uint)rand.Next(0, 1024);
             _encoded2d = Tedd.Legacy.MortonEncoding.Encode(_x, _y);
             _encoded3d = Tedd.Legacy.MortonEncoding.Encode(_x, _y, _z);
         }

--- a/src/Tedd.MortonEncoding.Benchmarks/EncodingBenchmark.cs
+++ b/src/Tedd.MortonEncoding.Benchmarks/EncodingBenchmark.cs
@@ -17,9 +17,9 @@ namespace Tedd.Benchmarks
         public void Setup()
         {
             var rand = new Random(42);
-            _x = (uint)rand.Next(0, 65536);
-            _y = (uint)rand.Next(0, 65536);
-            _z = (uint)rand.Next(0, 1024);
+            _x = (uint)rand.Next(0, 65535);
+            _y = (uint)rand.Next(0, 65535);
+            _z = (uint)rand.Next(0, 1023);
             _encoded2d = Tedd.Legacy.MortonEncoding.Encode(_x, _y);
             _encoded3d = Tedd.Legacy.MortonEncoding.Encode(_x, _y, _z);
         }

--- a/src/Tedd.MortonEncoding.Benchmarks/EncodingBenchmark.cs
+++ b/src/Tedd.MortonEncoding.Benchmarks/EncodingBenchmark.cs
@@ -1,0 +1,51 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using System;
+
+namespace Tedd.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class EncodingBenchmark
+    {
+        private uint _x;
+        private uint _y;
+        private uint _z;
+        private uint _encoded2d;
+        private uint _encoded3d;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var rand = new Random(42);
+            _x = (uint)rand.Next(0, 65535);
+            _y = (uint)rand.Next(0, 65535);
+            _z = (uint)rand.Next(0, 1023);
+            _encoded2d = Tedd.Legacy.MortonEncoding.Encode(_x, _y);
+            _encoded3d = Tedd.Legacy.MortonEncoding.Encode(_x, _y, _z);
+        }
+
+        [Benchmark(Baseline = true)]
+        public uint LegacyEncode2D() => Tedd.Legacy.MortonEncoding.Encode(_x, _y);
+
+        [Benchmark]
+        public uint OptimizedEncode2D() => Tedd.MortonEncoding.Encode(_x, _y);
+
+        [Benchmark]
+        public uint LegacyEncode3D() => Tedd.Legacy.MortonEncoding.Encode(_x, _y, _z);
+
+        [Benchmark]
+        public uint OptimizedEncode3D() => Tedd.MortonEncoding.Encode(_x, _y, _z);
+
+        [Benchmark]
+        public void LegacyDecode2D() => Tedd.Legacy.MortonEncoding.Decode(_encoded2d, out _, out _);
+
+        [Benchmark]
+        public void OptimizedDecode2D() => Tedd.MortonEncoding.Decode(_encoded2d, out _, out _);
+
+        [Benchmark]
+        public void LegacyDecode3D() => Tedd.Legacy.MortonEncoding.Decode(_encoded3d, out _, out _, out _);
+
+        [Benchmark]
+        public void OptimizedDecode3D() => Tedd.MortonEncoding.Decode(_encoded3d, out _, out _, out _);
+    }
+}

--- a/src/Tedd.MortonEncoding.Benchmarks/Program.cs
+++ b/src/Tedd.MortonEncoding.Benchmarks/Program.cs
@@ -1,0 +1,12 @@
+using BenchmarkDotNet.Running;
+
+namespace Tedd.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var summary = BenchmarkRunner.Run<SoftwareFallbackBenchmark>();
+        }
+    }
+}

--- a/src/Tedd.MortonEncoding.Benchmarks/Program.cs
+++ b/src/Tedd.MortonEncoding.Benchmarks/Program.cs
@@ -6,7 +6,7 @@ namespace Tedd.Benchmarks
     {
         static void Main(string[] args)
         {
-            var summary = BenchmarkRunner.Run<SoftwareFallbackBenchmark>();
+            BenchmarkRunner.Run<SoftwareFallbackBenchmark>();
         }
     }
 }

--- a/src/Tedd.MortonEncoding.Benchmarks/Program.cs
+++ b/src/Tedd.MortonEncoding.Benchmarks/Program.cs
@@ -6,7 +6,7 @@ namespace Tedd.Benchmarks
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<SoftwareFallbackBenchmark>();
+            var summary = BenchmarkRunner.Run<SoftwareFallbackBenchmark>();
         }
     }
 }

--- a/src/Tedd.MortonEncoding.Benchmarks/SoftwareFallbackBenchmark.cs
+++ b/src/Tedd.MortonEncoding.Benchmarks/SoftwareFallbackBenchmark.cs
@@ -14,8 +14,8 @@ namespace Tedd.Benchmarks
         public void Setup()
         {
             var rand = new Random(42);
-            _x = (uint)rand.Next(0, 65536);
-            _y = (uint)rand.Next(0, 65536);
+            _x = (uint)rand.Next(0, 65535);
+            _y = (uint)rand.Next(0, 65535);
         }
 
         [Benchmark(Baseline = true)]

--- a/src/Tedd.MortonEncoding.Benchmarks/SoftwareFallbackBenchmark.cs
+++ b/src/Tedd.MortonEncoding.Benchmarks/SoftwareFallbackBenchmark.cs
@@ -14,8 +14,8 @@ namespace Tedd.Benchmarks
         public void Setup()
         {
             var rand = new Random(42);
-            _x = (uint)rand.Next(0, 65535);
-            _y = (uint)rand.Next(0, 65535);
+            _x = (uint)rand.Next(0, 65536);
+            _y = (uint)rand.Next(0, 65536);
         }
 
         [Benchmark(Baseline = true)]

--- a/src/Tedd.MortonEncoding.Benchmarks/SoftwareFallbackBenchmark.cs
+++ b/src/Tedd.MortonEncoding.Benchmarks/SoftwareFallbackBenchmark.cs
@@ -1,0 +1,61 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using System;
+
+namespace Tedd.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class SoftwareFallbackBenchmark
+    {
+        private uint _x;
+        private uint _y;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var rand = new Random(42);
+            _x = (uint)rand.Next(0, 65535);
+            _y = (uint)rand.Next(0, 65535);
+        }
+
+        [Benchmark(Baseline = true)]
+        public uint LegacyEncode2D()
+        {
+            uint x = _x;
+            uint y = _y;
+            x = (x | x << 16) & 0x0000FFFF;
+            x = (x | x << 8) & 0x00FF00FF;
+            x = (x | x << 4) & 0x0F0F0F0F;
+            x = (x | x << 2) & 0x33333333;
+            x = (x | x << 1) & 0x55555555;
+
+            y = (y | y << 16) & 0x0000FFFF;
+            y = (y | y << 8) & 0x00FF00FF;
+            y = (y | y << 4) & 0x0F0F0F0F;
+            y = (y | y << 2) & 0x33333333;
+            y = (y | y << 1) & 0x55555555;
+
+            return x | (y << 1);
+        }
+
+        [Benchmark]
+        public uint OptimizedEncode2D()
+        {
+            uint x = _x;
+            uint y = _y;
+            x = x & 0x0000FFFF;
+            x = (x | x << 8) & 0x00FF00FF;
+            x = (x | x << 4) & 0x0F0F0F0F;
+            x = (x | x << 2) & 0x33333333;
+            x = (x | x << 1) & 0x55555555;
+
+            y = y & 0x0000FFFF;
+            y = (y | y << 8) & 0x00FF00FF;
+            y = (y | y << 4) & 0x0F0F0F0F;
+            y = (y | y << 2) & 0x33333333;
+            y = (y | y << 1) & 0x55555555;
+
+            return x | (y << 1);
+        }
+    }
+}

--- a/src/Tedd.MortonEncoding.Benchmarks/Tedd.MortonEncoding.Benchmarks.csproj
+++ b/src/Tedd.MortonEncoding.Benchmarks/Tedd.MortonEncoding.Benchmarks.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tedd.MortonEncoding\Tedd.MortonEncoding.csproj" />
+    <ProjectReference Include="..\Tedd.MortonEncoding.Legacy\Tedd.MortonEncoding.Legacy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tedd.MortonEncoding.Legacy/MortonEncoding.Legacy.cs
+++ b/src/Tedd.MortonEncoding.Legacy/MortonEncoding.Legacy.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Tedd.Legacy
+{
+    public static class MortonEncoding
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SplitXY(UInt32 i, int bits, out UInt32 x, out UInt32 y)
+        {
+            var mask = ((UInt32)1 << bits) - 1;
+            x = (i >> bits) & mask;
+            y = i & mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SplitXYZ(UInt32 i, int bits, out UInt32 x, out UInt32 y, out UInt32 z)
+        {
+            var mask = ((UInt32)1 << bits) - 1;
+            x = (i >> (bits + bits)) & mask;
+            y = (i >> bits) & mask;
+            z = i & mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static UInt32 Encode(UInt32 x, UInt32 y)
+        {
+            {
+                //x =  0x0000FFFF;
+                x = (x | x << 16) & 0x0000FFFF; // Should only shift one, right? But then we need twice as many operators?
+                x = (x | x << 8) & 0x00FF00FF;
+                x = (x | x << 4) & 0x0F0F0F0F;
+                x = (x | x << 2) & 0x33333333;
+                x = (x | x << 1) & 0x55555555;
+
+                y = (y | y << 16) & 0x0000FFFF;
+                y = (y | y << 8) & 0x00FF00FF;
+                y = (y | y << 4) & 0x0F0F0F0F;
+                y = (y | y << 2) & 0x33333333;
+                y = (y | y << 1) & 0x55555555;
+
+
+                return x | (y << 1);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Decode(UInt32 morton, out UInt32 x, out UInt32 y)
+        {
+            {
+                x = morton & 0x55555555;
+                x = (x ^ (x >> 1)) & 0x33333333;
+                x = (x ^ (x >> 2)) & 0x0F0F0F0F;
+                x = (x ^ (x >> 4)) & 0x00FF00FF;
+                x = (x ^ (x >> 8)) & 0x0000FFFF;
+
+                y = (morton >> 1) & 0x55555555;
+                y = (y ^ (y >> 1)) & 0x33333333;
+                y = (y ^ (y >> 2)) & 0x0F0F0F0F;
+                y = (y ^ (y >> 4)) & 0x00FF00FF;
+                y = (y ^ (y >> 8)) & 0x0000FFFF;
+
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static UInt32 Encode(UInt32 x, UInt32 y, UInt32 z)
+        {
+            {
+                x = (x | (x << 16)) & 0x030000FF;
+                x = (x | (x << 8)) & 0x0300F00F;
+                x = (x | (x << 4)) & 0x030C30C3;
+                x = (x | (x << 2)) & 0x09249249;
+
+                y = (y | (y << 16)) & 0x030000FF;
+                y = (y | (y << 8)) & 0x0300F00F;
+                y = (y | (y << 4)) & 0x030C30C3;
+                y = (y | (y << 2)) & 0x09249249;
+
+                z = (z | (z << 16)) & 0x030000FF;
+                z = (z | (z << 8)) & 0x0300F00F;
+                z = (z | (z << 4)) & 0x030C30C3;
+                z = (z | (z << 2)) & 0x09249249;
+
+                return x | (y << 1) | (z << 2);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Decode(UInt32 morton, out UInt32 x, out UInt32 y, out UInt32 z)
+        {
+            {
+                x = morton & 0x9249249;
+                x = (x ^ (x >> 2)) & 0x30c30c3;
+                x = (x ^ (x >> 4)) & 0x0300f00f;
+                x = (x ^ (x >> 8)) & 0x30000ff;
+                x = (x ^ (x >> 16)) & 0x000003ff;
+
+                y = (morton >> 1) & 0x9249249;
+                y = (y ^ (y >> 2)) & 0x30c30c3;
+                y = (y ^ (y >> 4)) & 0x0300f00f;
+                y = (y ^ (y >> 8)) & 0x30000ff;
+                y = (y ^ (y >> 16)) & 0x000003ff;
+
+                z = (morton >> 2) & 0x9249249;
+                z = (z ^ (z >> 2)) & 0x30c30c3;
+                z = (z ^ (z >> 4)) & 0x0300f00f;
+                z = (z ^ (z >> 8)) & 0x30000ff;
+                z = (z ^ (z >> 16)) & 0x000003ff;
+
+            }
+        }
+
+    }
+}

--- a/src/Tedd.MortonEncoding.Legacy/Tedd.MortonEncoding.Legacy.csproj
+++ b/src/Tedd.MortonEncoding.Legacy/Tedd.MortonEncoding.Legacy.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tedd.MortonEncoding.Tests/Tedd.MortonEncoding.Tests.csproj
+++ b/src/Tedd.MortonEncoding.Tests/Tedd.MortonEncoding.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Tedd.MortonEncoding.Tests/Tedd.MortonEncoding.Tests.csproj
+++ b/src/Tedd.MortonEncoding.Tests/Tedd.MortonEncoding.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Tedd.MortonEncoding/MortonEncoding.cs
+++ b/src/Tedd.MortonEncoding/MortonEncoding.cs
@@ -37,13 +37,13 @@ namespace Tedd
 #endif
             {
                 //x =  0x0000FFFF;
-                x = x & 0x0000FFFF; // Eliminating redundant SHIFT and OR operations before masking top 16 bits. O(1) Time, O(1) Space
+                x = x & 0x0000FFFF; // Eliminating redundant SHIFT and OR operations before masking top 16 bits. O(1) Time / O(1) Space.
                 x = (x | x << 8) & 0x00FF00FF;
                 x = (x | x << 4) & 0x0F0F0F0F;
                 x = (x | x << 2) & 0x33333333;
                 x = (x | x << 1) & 0x55555555;
 
-                y = y & 0x0000FFFF; // O(1) Time, O(1) Space
+                y = y & 0x0000FFFF; // O(1) Time / O(1) Space.
                 y = (y | y << 8) & 0x00FF00FF;
                 y = (y | y << 4) & 0x0F0F0F0F;
                 y = (y | y << 2) & 0x33333333;

--- a/src/Tedd.MortonEncoding/MortonEncoding.cs
+++ b/src/Tedd.MortonEncoding/MortonEncoding.cs
@@ -37,13 +37,13 @@ namespace Tedd
 #endif
             {
                 //x =  0x0000FFFF;
-                x = (x | x << 16) & 0x0000FFFF; // Should only shift one, right? But then we need twice as many operators?
+                x = x & 0x0000FFFF; // Eliminating redundant SHIFT and OR operations before masking top 16 bits. O(1) Time, O(1) Space
                 x = (x | x << 8) & 0x00FF00FF;
                 x = (x | x << 4) & 0x0F0F0F0F;
                 x = (x | x << 2) & 0x33333333;
                 x = (x | x << 1) & 0x55555555;
 
-                y = (y | y << 16) & 0x0000FFFF;
+                y = y & 0x0000FFFF; // O(1) Time, O(1) Space
                 y = (y | y << 8) & 0x00FF00FF;
                 y = (y | y << 4) & 0x0F0F0F0F;
                 y = (y | y << 2) & 0x33333333;


### PR DESCRIPTION
💡 **Hypothesis:** 
The software fallback for the 2D `Encode(UInt32 x, UInt32 y)` function contained mathematically redundant operations. Specifically, `x = (x | x << 16) & 0x0000FFFF` shifts bits to the upper 16 positions, applies an OR operation, and then immediately applies a mask (`0x0000FFFF`) that clears those identical bits. 

🎯 **Execution:**
Eliminated the redundant bitwise `OR` (`|`) and `SHIFT` (`<<`) operations in both `x` and `y` axes prior to the top 16 bits mask, simplifying the execution to `x = x & 0x0000FFFF`. This removes 4 dead instructions per encode. Evaluated complexity is O(1) Time / O(1) Space.

📊 **Empirical Impact:** 

BenchmarkDotNet v0.15.8, Linux Ubuntu 24.04.4 LTS (Noble Numbat)
Intel Xeon Processor 2.30GHz, 1 CPU, 4 logical and 4 physical cores
.NET SDK 10.0.103
  [Host]     : .NET 10.0.3 (10.0.3, 10.0.326.7603), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.3 (10.0.3, 10.0.326.7603), X64 RyuJIT x86-64-v3

| Method            | Mean     | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------ |---------:|----------:|----------:|------:|--------:|----------:|------------:|
| LegacyEncode2D    | 3.153 ns | 0.0433 ns | 0.0362 ns |  1.00 |    0.02 |         - |          NA |
| OptimizedEncode2D | 2.633 ns | 0.0197 ns | 0.0154 ns |  0.84 |    0.01 |         - |          NA |


🔬 **Verification Protocol:** 
1. Symmetric A/B test setup constructed leveraging `Tedd.MortonEncoding.Legacy` archive logic alongside `Tedd.MortonEncoding`.
2. Validated by running `src/Tedd.MortonEncoding.Benchmarks` using `DOTNET_EnableBMI2=0 dotnet run -c Release` to forcibly evaluate the software fallback on intrinsically supported CPUs.

---
*PR created automatically by Jules for task [888781959563311050](https://jules.google.com/task/888781959563311050) started by @tedd*